### PR TITLE
Not to raise error in parse, to be able to use Safe.readMay etc.

### DIFF
--- a/Data/IP/Addr.hs
+++ b/Data/IP/Addr.hs
@@ -169,16 +169,16 @@ parseIP cs = case runParser ip4 cs of
     (Just ip,rest) -> [(IPv4 ip,rest)]
     (Nothing,_) -> case runParser ip6 cs of
         (Just ip,rest) -> [(IPv6 ip,rest)]
-        (Nothing,_) -> error $ "parseIP" ++ cs
+        (Nothing,_) -> []
 
 parseIPv4 :: String -> [(IPv4,String)]
 parseIPv4 cs = case runParser ip4 cs of
-    (Nothing,_)    -> error $ "parseIPv4 " ++ cs
+    (Nothing,_)    -> []
     (Just a4,rest) -> [(a4,rest)]
 
 parseIPv6 :: String -> [(IPv6,String)]
 parseIPv6 cs = case runParser ip6 cs of
-    (Nothing,_)    -> error $ "parseIPv6 " ++ cs
+    (Nothing,_)    -> []
     (Just a6,rest) -> [(a6,rest)]
 
 ----------------------------------------------------------------


### PR DESCRIPTION
read で呼ばれる parseIP 関数内で error すると、read失敗エラーと違うため、
safe パッケージの Safe.readMay 関数などで対応できません。
今回の変更で対応できるようになります。

付属のテストの実行方法がわからず、付属テストを通していません。
cabal ファイルに test セクションを作って付属テストを実行しようとしたのですが、
Internalな関数を使うテストが含まれているため実行できませんでした。

よろしくお願いします。
