### PR TITLE
Fixed not to use "error" in the read of AddrRange IPv4/IPv6

### DIFF
--- a/Data/IP/Range.hs
+++ b/Data/IP/Range.hs
@@ -78,7 +78,7 @@ parseIPRange cs = case runParser ip4range cs of
     (Just ip,rest) -> [(IPv4Range ip,rest)]
     (Nothing,_)    -> case runParser ip6range cs of
         (Just ip,rest) -> [(IPv6Range ip,rest)]
-        (Nothing,_) -> error $ "parseIPRange" ++ cs
+        (Nothing,_) -> []
 
 instance Read (AddrRange IPv4) where
     readsPrec _ = parseIPv4Range
@@ -88,12 +88,12 @@ instance Read (AddrRange IPv6) where
 
 parseIPv4Range :: String -> [(AddrRange IPv4,String)]
 parseIPv4Range cs = case runParser ip4range cs of
-    (Nothing,_)    -> error $ "parseIPv4Range " ++ cs
+    (Nothing,_)    -> []
     (Just a4,rest) -> [(a4,rest)]
 
 parseIPv6Range :: String -> [(AddrRange IPv6,String)]
 parseIPv6Range cs = case runParser ip6range cs of
-    (Nothing,_)    -> error $ "parseIPv6Range " ++ cs
+    (Nothing,_)    -> []
     (Just a6,rest) -> [(a6,rest)]
 
 ip4range :: Parser (AddrRange IPv4)

--- a/iproute.cabal
+++ b/iproute.cabal
@@ -47,6 +47,7 @@ Test-Suite spec
   Ghc-Options:          -Wall
   Main-Is:              Spec.hs
   Other-Modules:        RouteTableSpec
+                      , IPReadSpec
   Build-Depends:        base
                       , hspec
                       , QuickCheck
@@ -54,6 +55,7 @@ Test-Suite spec
                       , byteorder
                       , containers
                       , network
+                      , Safe
 
 Source-Repository head
   Type:                 git

--- a/test/IPReadSpec.hs
+++ b/test/IPReadSpec.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module IPReadSpec where
+
+import Data.IP
+import Safe (readMay)
+import Test.Hspec
+import Test.Hspec.QuickCheck (prop)
+import Test.QuickCheck
+
+import RouteTableSpec ()
+
+----------------------------------------------------------------
+--
+-- Arbitrary
+--
+
+data InvalidIPv4Str = Iv4 String deriving (Show)
+
+instance Arbitrary InvalidIPv4Str where
+    arbitrary = arbitraryIIPv4Str arbitrary 32
+
+arbitraryIIPv4Str :: Gen IPv4 -> Int -> Gen InvalidIPv4Str
+arbitraryIIPv4Str adrGen msklen = do
+    adr <- adrGen
+    len <- oneof [choose (minBound, -1), choose (msklen + 1, maxBound)]
+    return $ Iv4 $ show adr ++ "/" ++ show len
+
+data InvalidIPv6Str = Iv6 String deriving (Show)
+
+instance Arbitrary InvalidIPv6Str where
+    arbitrary = arbitraryIIPv6Str arbitrary 128
+
+arbitraryIIPv6Str :: Gen IPv6 -> Int -> Gen InvalidIPv6Str
+arbitraryIIPv6Str adrGen msklen = do
+    adr <- adrGen
+    len <- oneof [choose (minBound, -1), choose (msklen + 1, maxBound)]
+    return $ Iv6 $ show adr ++ "/" ++ show len
+
+----------------------------------------------------------------
+--
+-- Spec
+--
+
+spec :: Spec
+spec = do
+    describe "read" $ do
+        prop "IPv4" to_str_ipv4
+        prop "IPv6" to_str_ipv6
+        prop "IPv4 failure" ipv4_fail
+        prop "IPv6 failure" ipv6_fail
+
+to_str_ipv4 :: AddrRange IPv4 -> Bool
+to_str_ipv4 a = (readMay $ show a) == Just a
+
+to_str_ipv6 :: AddrRange IPv6 -> Bool
+to_str_ipv6 a = (readMay $ show a) == Just a
+
+ipv4_fail :: InvalidIPv4Str -> Bool
+ipv4_fail (Iv4 a) = (readMay a :: Maybe (AddrRange IPv4)) == Nothing
+
+ipv6_fail :: InvalidIPv6Str -> Bool
+ipv6_fail (Iv6 a) = (readMay a :: Maybe (AddrRange IPv6)) == Nothing


### PR DESCRIPTION
#6 と同様に、AddrRangeのread(parseIPv4Range/parseIPv6Range)でもerror関数が使われていたため、Safe.readMayが使えなくなっていたので修正しました。

Rangeに関する部分だけですがテストも書きました。

よろしくお願いします。
