### PR TITLE
replace obsolete `Safe` library with the newer version `safe`

### DIFF
--- a/iproute.cabal
+++ b/iproute.cabal
@@ -55,7 +55,7 @@ Test-Suite spec
                       , byteorder
                       , containers
                       , network
-                      , Safe
+                      , safe
 
 Source-Repository head
   Type:                 git


### PR DESCRIPTION
Both packages have the same API, so the change is transparent.
