### PR TITLE
Add instance Ord IP

### DIFF
--- a/Data/IP/Addr.hs
+++ b/Data/IP/Addr.hs
@@ -25,7 +25,7 @@ True
 
 data IP = IPv4 { ipv4 :: IPv4 }
         | IPv6 { ipv6 :: IPv6 }
-        deriving (Eq)
+        deriving (Eq, Ord)
 
 instance Show IP where
     show (IPv4 ip) = show ip


### PR DESCRIPTION
It is often pretty useful to put a bunch of `IP`s to a `Set` or `Map`. Any particular reason the IP datatype do not have Ord instance?
