### PR TITLE
Show IPv6 in appropriate notation proposed by RFC 5952.

### DIFF
--- a/Data/IP/Op.hs
+++ b/Data/IP/Op.hs
@@ -77,7 +77,7 @@ isMatchedTo a r = a `masked` mask r == addr r
 >>> makeAddrRange (toIPv4 [127,0,2,1]) 8
 127.0.0.0/8
 >>> makeAddrRange (toIPv6 [0x2001,0xDB8,0,0,0,0,0,1]) 8
-2000:00:00:00:00:00:00:00/8
+2000::/8
 -}
 makeAddrRange :: Addr a => a -> Int -> AddrRange a
 makeAddrRange ad len = AddrRange adr msk len

--- a/Data/IP/Range.hs
+++ b/Data/IP/Range.hs
@@ -50,7 +50,7 @@ data IPRange = IPv4Range { ipv4range :: AddrRange IPv4 }
 >>> read "192.0.2.1/24" :: AddrRange IPv4
 192.0.2.0/24
 >>> read "2001:db8:00:00:00:00:00:01/48" :: AddrRange IPv6
-2001:db8:00:00:00:00:00:00/48
+2001:db8::/48
 -}
 data AddrRange a = AddrRange {
         -- |The 'addr' function returns an address from 'AddrRange'.


### PR DESCRIPTION
Show an IPv6 address in the most appropriate notation, based on the recommended representation proposed in section 4 and section 5 in [RFC 5952](http://tools.ietf.org/html/rfc5952).

The implementation is pure and completely compatible with the current implementation of the `inet_ntop` function in glibc.
