### PR TITLE
make toIPv6/fromIPv6 work with byte-lists

### DIFF
--- a/Data/IP.hs
+++ b/Data/IP.hs
@@ -6,7 +6,7 @@ module Data.IP (
   -- ** IP data
     IP (..)
   , IPv4, toIPv4, fromIPv4, fromHostAddress, toHostAddress
-  , IPv6, toIPv6, fromIPv6, fromHostAddress6, toHostAddress6
+  , IPv6, toIPv6, toIPv6', fromIPv6, fromIPv6', fromHostAddress6, toHostAddress6
   -- ** IP range data
   , IPRange (..)
   , AddrRange (addr, mask, mlen)

--- a/Data/IP.hs
+++ b/Data/IP.hs
@@ -6,7 +6,7 @@ module Data.IP (
   -- ** IP data
     IP (..)
   , IPv4, toIPv4, fromIPv4, fromHostAddress, toHostAddress
-  , IPv6, toIPv6, toIPv6', fromIPv6, fromIPv6', fromHostAddress6, toHostAddress6
+  , IPv6, toIPv6, toIPv6b, fromIPv6, fromIPv6b, fromHostAddress6, toHostAddress6
   -- ** IP range data
   , IPRange (..)
   , AddrRange (addr, mask, mlen)

--- a/Data/IP/Addr.hs
+++ b/Data/IP/Addr.hs
@@ -164,7 +164,7 @@ toIPv6 ad = IP6 (x1,x2,x3,x4)
   The 'toIPv6b' function takes a list of 'Int'
   where each member repserents a single byte and returns 'IPv6'.
 
->>> toIPv6 [0x20,0x01,0xD,0xB8,0,0,0,0,0,0,0,0,0,0,0,1]
+>>> toIPv6b [0x20,0x01,0xD,0xB8,0,0,0,0,0,0,0,0,0,0,0,1]
 2001:db8::1
 -}
 toIPv6b :: [Int] -> IPv6
@@ -206,7 +206,7 @@ fromIPv6 (IP6 (w1, w2, w3, w4)) = map fromEnum (concatMap split [w1,w2,w3,w4])
   The 'fromIPv6b' function converts 'IPv6' to a list of 'Int'
   where each member represents a single byte.
 
->>> fromIPv6 (toIPv6 [0x20,0x01,0xD,0xB8,0,0,0,0,0,0,0,0,0,0,0,1])
+>>> fromIPv6b (toIPv6b [0x20,0x01,0xD,0xB8,0,0,0,0,0,0,0,0,0,0,0,1])
 [32,1,13,184,0,0,0,0,0,0,0,0,0,0,0,1]
 -}
 fromIPv6b :: IPv6 -> [Int]

--- a/Data/IP/Addr.hs
+++ b/Data/IP/Addr.hs
@@ -160,6 +160,22 @@ toIPv6 ad = IP6 (x1,x2,x3,x4)
     toWord32 [a1,a2] = fromIntegral $ shift a1 16 + a2
     toWord32 _       = error "toWord32"
 
+{-|
+  The 'toIPv6b' function takes a list of 'Int'
+  where each member repserents a single byte and returns 'IPv6'.
+
+>>> toIPv6 [0x20,0x01,0xD,0xB8,0,0,0,0,0,0,0,0,0,0,0,1]
+2001:db8::1
+-}
+toIPv6b :: [Int] -> IPv6
+toIPv6b ad = IP6 (x1,x2,x3,x4)
+  where
+    [x1,x2,x3,x4] = map toWord32 $ split4 ad
+    split4 [] = []
+    split4 x  = take 4 x : split4 (drop 4 x)
+    toWord32 [a1,a2,a3,a4] = fromIntegral $ shift a1 24 + shift a2 16 + shift a3 8 + a4
+    toWord32 _       = error "toWord32"
+
 ----------------------------------------------------------------
 --
 -- IPToInt
@@ -185,6 +201,18 @@ fromIPv6 (IP6 (w1, w2, w3, w4)) = map fromEnum (concatMap split [w1,w2,w3,w4])
   where
     split :: Word32 -> [Word32]
     split n = [n `shiftR` 0x10 .&. 0xffff, n .&. 0xffff]
+
+{-|
+  The 'fromIPv6b' function converts 'IPv6' to a list of 'Int'
+  where each member represents a single byte.
+
+>>> fromIPv6 (toIPv6 [0x20,0x01,0xD,0xB8,0,0,0,0,0,0,0,0,0,0,0,1])
+[32,1,13,184,0,0,0,0,0,0,0,0,0,0,0,1]
+-}
+fromIPv6b :: IPv6 -> [Int]
+fromIPv6b (IP6 (w1, w2, w3, w4)) = map fromEnum (concatMap split [w1,w2,w3,w4])
+  where
+    split n = fmap (\s -> n `shiftR` s .&. 0xff) [24,16,8,0]
 
 ----------------------------------------------------------------
 --


### PR DESCRIPTION
Hey,

This change makes toIPv[46] and fromIPv[46] more consistent, and makes reading IPv6 addresses from raw bytestrings much easier. The downside is it breaks the API compatibility.