### PR TITLE
add Foldable and Traversable instances to IPRTable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: haskell
 ghc:
-  - 7.4
   - 7.6
   - 7.8

--- a/Data/IP/RouteTable/Internal.hs
+++ b/Data/IP/RouteTable/Internal.hs
@@ -7,15 +7,17 @@
 -}
 module Data.IP.RouteTable.Internal where
 
-import Control.Applicative ((<$>))
+import Control.Applicative ((<$>),(<*>),pure)
 import Control.Monad
 import Data.Bits
+import Data.Foldable (Foldable(..))
 import Data.IP.Addr
 import Data.IP.Op
 import Data.IP.Range
 import Data.IntMap (IntMap, (!))
 import qualified Data.IntMap as IM (fromList)
-import Data.List (foldl')
+import Data.Monoid
+import Data.Traversable
 import Data.Word
 import Prelude hiding (lookup)
 
@@ -100,6 +102,14 @@ empty = Nil
 instance Functor (IPRTable k) where
     fmap _ Nil = Nil
     fmap f (Node r a mv b1 b2) = Node r a (f <$> mv) (fmap f b1) (fmap f b2)
+
+instance Foldable (IPRTable k) where
+    foldMap _ Nil = mempty
+    foldMap f (Node _ _ mv b1 b2) = foldMap f mv <> foldMap f b1 <> foldMap f b2
+
+instance Traversable (IPRTable k) where
+    traverse _ Nil = pure Nil
+    traverse f (Node r a mv b1 b2) = Node r a <$> traverse f mv <*> traverse f b1 <*> traverse f b2
 
 ----------------------------------------------------------------
 


### PR DESCRIPTION
Maybe it is a good idea to drop the internal toList implementation in favor of the one from Data.Foldable?