### PR TITLE
Doesn't build on GHC < 7.6

### DIFF
--- a/iproute.cabal
+++ b/iproute.cabal
@@ -25,7 +25,7 @@ Library
                         Data.IP.Op
                         Data.IP.Range
                         Data.IP.RouteTable.Internal
-  Build-Depends:        base >= 4 && < 5
+  Build-Depends:        base >= 4.6 && < 5
                       , appar
                       , byteorder
                       , containers


### PR DESCRIPTION
```
Data/IP/RouteTable/Internal.hs:261:12:
    Not in scope: foldl'
    Perhaps you meant one of these:
      `foldl1' (imported from Data.Foldable),
      `foldl1' (imported from Prelude),
      `foldl' (imported from Data.Foldable)
```