### PR TITLE
Add instance Ord IPRange

### DIFF
--- a/Data/IP/Range.hs
+++ b/Data/IP/Range.hs
@@ -28,9 +28,9 @@ True
 data IPRange = IPv4Range { ipv4range :: AddrRange IPv4 }
              | IPv6Range { ipv6range :: AddrRange IPv6 }
 #ifdef GENERICS
-        deriving (Eq, Generic)
+        deriving (Eq, Ord, Generic)
 #else
-        deriving (Eq)
+        deriving (Eq, Ord)
 #endif
 
 ----------------------------------------------------------------


### PR DESCRIPTION
Required for using IPRange as a key in persistent.