### PR TITLE
Generic, Data, and Typeable instances

### DIFF
--- a/Data/IP/Addr.hs
+++ b/Data/IP/Addr.hs
@@ -8,6 +8,7 @@ import Data.Char
 import Data.Data (Data)
 import Data.List (foldl', intersperse)
 import Data.String
+import Data.Typeable (Typeable)
 import Data.Word
 import Network.Socket
 import Numeric (showHex, showInt)
@@ -30,7 +31,7 @@ True
 
 data IP = IPv4 { ipv4 :: IPv4 }
         | IPv6 { ipv6 :: IPv6 }
-        deriving (Data,Generic)
+        deriving (Data,Generic,Typeable)
 
 {-|
   Equality over IP addresses. Correctly compare IPv4 and IPv4-embedded-in-IPv6 addresses.
@@ -83,7 +84,7 @@ type IPv6Addr = (Word32,Word32,Word32,Word32)
 192.0.2.1
 -}
 newtype IPv4 = IP4 IPv4Addr
-  deriving (Eq, Ord, Bounded, Data, Generic)
+  deriving (Eq, Ord, Bounded, Data, Generic, Typeable)
 
 {-|
   The abstract data type to express an IPv6 address.
@@ -105,7 +106,7 @@ newtype IPv4 = IP4 IPv4Addr
 ::1
 -}
 newtype IPv6 = IP6 IPv6Addr
-  deriving (Eq, Ord, Bounded, Data, Generic)
+  deriving (Eq, Ord, Bounded, Data, Generic, Typeable)
 
 
 ----------------------------------------------------------------

--- a/Data/IP/Addr.hs
+++ b/Data/IP/Addr.hs
@@ -1,9 +1,11 @@
-{-# LANGUAGE DeriveGeneric  #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric      #-}
 module Data.IP.Addr where
 
 import Control.Monad
 import Data.Bits
 import Data.Char
+import Data.Data (Data)
 import Data.List (foldl', intersperse)
 import Data.String
 import Data.Word
@@ -28,7 +30,7 @@ True
 
 data IP = IPv4 { ipv4 :: IPv4 }
         | IPv6 { ipv6 :: IPv6 }
-        deriving (Generic)
+        deriving (Data,Generic)
 
 {-|
   Equality over IP addresses. Correctly compare IPv4 and IPv4-embedded-in-IPv6 addresses.
@@ -81,7 +83,7 @@ type IPv6Addr = (Word32,Word32,Word32,Word32)
 192.0.2.1
 -}
 newtype IPv4 = IP4 IPv4Addr
-  deriving (Eq, Ord, Bounded, Generic)
+  deriving (Eq, Ord, Bounded, Data, Generic)
 
 {-|
   The abstract data type to express an IPv6 address.
@@ -103,7 +105,7 @@ newtype IPv4 = IP4 IPv4Addr
 ::1
 -}
 newtype IPv6 = IP6 IPv6Addr
-  deriving (Eq, Ord, Bounded, Generic)
+  deriving (Eq, Ord, Bounded, Data, Generic)
 
 
 ----------------------------------------------------------------

--- a/Data/IP/Addr.hs
+++ b/Data/IP/Addr.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE DeriveGeneric  #-}
 module Data.IP.Addr where
 
 import Control.Monad
@@ -12,9 +12,7 @@ import Numeric (showHex, showInt)
 import System.ByteOrder
 import Text.Appar.String
 import GHC.Enum (succError,predError)
-#ifdef GENERICS
 import GHC.Generics
-#endif
 
 ----------------------------------------------------------------
 
@@ -30,9 +28,7 @@ True
 
 data IP = IPv4 { ipv4 :: IPv4 }
         | IPv6 { ipv6 :: IPv6 }
-#ifdef GENERICS
         deriving (Generic)
-#endif
 
 {-|
   Equality over IP addresses. Correctly compare IPv4 and IPv4-embedded-in-IPv6 addresses.
@@ -85,11 +81,7 @@ type IPv6Addr = (Word32,Word32,Word32,Word32)
 192.0.2.1
 -}
 newtype IPv4 = IP4 IPv4Addr
-#ifdef GENERICS
   deriving (Eq, Ord, Bounded, Generic)
-#else
-  deriving (Eq, Ord, Bounded)
-#endif
 
 {-|
   The abstract data type to express an IPv6 address.
@@ -111,11 +103,7 @@ newtype IPv4 = IP4 IPv4Addr
 ::1
 -}
 newtype IPv6 = IP6 IPv6Addr
-#ifdef GENERICS
   deriving (Eq, Ord, Bounded, Generic)
-#else
-  deriving (Eq, Ord, Bounded)
-#endif
 
 
 ----------------------------------------------------------------

--- a/Data/IP/Range.hs
+++ b/Data/IP/Range.hs
@@ -1,9 +1,11 @@
-{-# LANGUAGE DeriveGeneric     #-}
-{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE FlexibleInstances  #-}
 module Data.IP.Range where
 
 import Control.Monad
 import Data.Bits
+import Data.Data (Data)
 import Data.IP.Addr
 import Data.IP.Mask
 import Data.String
@@ -25,7 +27,7 @@ True
 
 data IPRange = IPv4Range { ipv4range :: AddrRange IPv4 }
              | IPv6Range { ipv6range :: AddrRange IPv6 }
-        deriving (Eq, Ord, Generic)
+        deriving (Eq, Ord, Data, Generic)
 
 ----------------------------------------------------------------
 --
@@ -54,7 +56,7 @@ data AddrRange a = AddrRange {
         -- |The 'mlen' function returns a mask length from 'AddrRange'.
       , mlen :: {-# UNPACK #-} !Int
     }
-    deriving (Eq, Ord, Generic)
+    deriving (Eq, Ord, Data, Generic)
 
 ----------------------------------------------------------------
 --

--- a/Data/IP/Range.hs
+++ b/Data/IP/Range.hs
@@ -1,5 +1,5 @@
+{-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE CPP #-}
 module Data.IP.Range where
 
 import Control.Monad
@@ -8,9 +8,7 @@ import Data.IP.Addr
 import Data.IP.Mask
 import Data.String
 import Text.Appar.String
-#ifdef GENERICS
 import GHC.Generics
-#endif
 
 ----------------------------------------------------------------
 
@@ -27,11 +25,7 @@ True
 
 data IPRange = IPv4Range { ipv4range :: AddrRange IPv4 }
              | IPv6Range { ipv6range :: AddrRange IPv6 }
-#ifdef GENERICS
         deriving (Eq, Ord, Generic)
-#else
-        deriving (Eq, Ord)
-#endif
 
 ----------------------------------------------------------------
 --
@@ -60,11 +54,7 @@ data AddrRange a = AddrRange {
         -- |The 'mlen' function returns a mask length from 'AddrRange'.
       , mlen :: {-# UNPACK #-} !Int
     }
-#ifdef GENERICS
     deriving (Eq, Ord, Generic)
-#else
-    deriving (Eq, Ord)
-#endif
 
 ----------------------------------------------------------------
 --

--- a/Data/IP/Range.hs
+++ b/Data/IP/Range.hs
@@ -9,6 +9,7 @@ import Data.Data (Data)
 import Data.IP.Addr
 import Data.IP.Mask
 import Data.String
+import Data.Typeable (Typeable)
 import Text.Appar.String
 import GHC.Generics
 
@@ -27,7 +28,7 @@ True
 
 data IPRange = IPv4Range { ipv4range :: AddrRange IPv4 }
              | IPv6Range { ipv6range :: AddrRange IPv6 }
-        deriving (Eq, Ord, Data, Generic)
+        deriving (Eq, Ord, Data, Generic, Typeable)
 
 ----------------------------------------------------------------
 --
@@ -56,7 +57,7 @@ data AddrRange a = AddrRange {
         -- |The 'mlen' function returns a mask length from 'AddrRange'.
       , mlen :: {-# UNPACK #-} !Int
     }
-    deriving (Eq, Ord, Data, Generic)
+    deriving (Eq, Ord, Data, Generic, Typeable)
 
 ----------------------------------------------------------------
 --

--- a/iproute.cabal
+++ b/iproute.cabal
@@ -32,13 +32,6 @@ Library
                       , containers
                       , network
 
-
-  if impl(ghc >= 7.2.1)
-    cpp-options:        -DGENERICS
-    default-extensions: DeriveGeneric
-  if impl(ghc >= 7.2.1) && impl(ghc < 7.6.1)
-    build-depends:      ghc-prim >= 0.2
-
 Test-Suite doctest
   Type:                 exitcode-stdio-1.0
   Default-Language:     Haskell2010


### PR DESCRIPTION
Given that ghc <7.6.1 support is no more, it seems reasonable to drop those ifdefs. This pull request also adds Data and Typeable instances for IP, IPv4, IPv6, IPRange, and AddrRange types.