### PR TITLE
Make to/from IPv4/IPv6 functions stricter.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ env:
  - CABALVER=1.24 GHCVER=8.0.2
  - CABALVER=2.0  GHCVER=8.2.2
  - CABALVER=2.2  GHCVER=8.4.2
+ - CABALVER=2.4  GHCVER=8.6.5
+ - CABALVER=3.0  GHCVER=8.8.2
  - CABALVER=head GHCVER=head   # see section about GHC HEAD snapshots
 
 matrix:
@@ -24,7 +26,10 @@ install:
  - cabal --version
  - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
  - travis_retry cabal update
- - cabal install --only-dependencies --enable-tests --enable-benchmarks
+ - case $CABALVER in [12].*) cabal install --only-dependencies --enable-tests --enable-benchmarks;; esac
+ - rm -fv cabal.project.local
+ - rm -f cabal.project.freeze
+ - cabal install hspec-discover
 
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
 script:
@@ -32,4 +37,4 @@ script:
  - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
  - cabal build   # this builds all libraries and executables (including tests/benchmarks)
  - cabal test
- - cabal check
+ - case $GHCVER in 8.*) cabal check;; esac

--- a/Data/IP.hs
+++ b/Data/IP.hs
@@ -5,9 +5,15 @@ module Data.IP (
   -- * IP data
     IP (..)
   -- ** IPv4
-  , IPv4, toIPv4, fromIPv4, fromHostAddress, toHostAddress
+  , IPv4
+  , toIPv4, toIPv4w
+  , fromIPv4, fromIPv4w
+  , fromHostAddress, toHostAddress
   -- ** IPv6
-  , IPv6, toIPv6, toIPv6b, fromIPv6, fromIPv6b, fromHostAddress6, toHostAddress6
+  , IPv6
+  , toIPv6, toIPv6b, toIPv6w
+  , fromIPv6, fromIPv6b, fromIPv6w
+  , fromHostAddress6, toHostAddress6
   -- ** Converters
   , ipv4ToIPv6
   , fromSockAddr

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,3 @@
+packages: .
+optimization: True
+write-ghc-environment-files: always

--- a/iproute.cabal
+++ b/iproute.cabal
@@ -14,6 +14,13 @@ Description:            IP Routing Table is a tree of IP ranges
 Category:               Algorithms, Network
 Cabal-Version:          >= 1.10
 Build-Type:             Simple
+Tested-With:            GHC == 7.8.4
+                      , GHC == 7.10.3
+                      , GHC == 8.0.2
+                      , GHC == 8.2.2
+                      , GHC == 8.4.4
+                      , GHC == 8.6.5
+                      , GHC == 8.8.2
 
 Library
   Default-Language:     Haskell2010
@@ -42,6 +49,9 @@ Test-Suite doctest
   Main-Is:              doctests.hs
   Build-Depends:        base >= 4.6 && < 5
                       , doctest >= 0.9.3
+                      , appar
+                      , byteorder
+                      , network
 
 Test-Suite spec
   Type:                 exitcode-stdio-1.0

--- a/test/doctests.hs
+++ b/test/doctests.hs
@@ -3,4 +3,9 @@ module Main where
 import Test.DocTest
 
 main :: IO ()
-main = doctest ["-XOverloadedStrings", "Data/IP.hs", "Data/IP/RouteTable.hs"]
+main = doctest [ "-XOverloadedStrings"
+               , "-package=appar"
+               , "-package=byteorder"
+               , "-package=network"
+               , "Data/IP.hs"
+               , "Data/IP/RouteTable.hs"]


### PR DESCRIPTION
These are basically structure getters/setters and should be strict in their input and produce fully-evaluated output.

Also new {to,from}{IPv4,IPv6}w functions provide efficient inlined non-copying getters/setters for the (current) internal representations of the addresses, speeding up bulk processing.  They're similar to the {to,from}HostAddress{,6} functions, but don't do byte order conversions and are strict.

Less terse documentation and a fix for a cut/paste error.

NOTE: The "to" functions now truncate each element to the expected number of bits. Previously, they'd just "+" un-truncated values leading to more surprising results when the input lists have elements with excess bits set.  I don't expect this to be a compatibility issue, but given malformed input the behaviour is now different.