### PR TITLE
Bump base version bounds to >= 4.9

### DIFF
--- a/iproute.cabal
+++ b/iproute.cabal
@@ -34,7 +34,7 @@ Library
                         Data.IP.Mask
                         Data.IP.Op
                         Data.IP.Range
-  Build-Depends:        base >= 4.6 && < 5
+  Build-Depends:        base >= 4.9 && < 5
                       , appar
                       , byteorder
                       , bytestring


### PR DESCRIPTION
`iproute` now only compiles on GHC 8.0 or later due to the use of `StrictData`, introduced in #49. This revises the lower version bounds on `base` accordingly so that `iproute` is not chosen in pre-8.0 build plans.

Fixes #53.