### PR TITLE
The tests need hspec-discover

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
           ghc: "8.4"
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-haskell@v1.1.3
+    - uses: haskell/actions/setup@v1
       id: setup-haskell-cabal
       with:
         ghc-version: ${{ matrix.ghc }}
@@ -37,11 +37,12 @@ jobs:
         path: |
           ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
           dist-newstyle
-        key: ${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
+        key: cache-${{ matrix.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
         restore-keys: |
-          ${{ runner.os }}-${{ matrix.ghc }}-
+          cache-${{ matrix.os }}-${{ matrix.ghc }}-
     - name: Build
       run: |
+        cabal install hspec-discover
         cabal build --disable-tests --disable-benchmarks all
     - name: Test
       run: |


### PR DESCRIPTION
This is a non-library executable dependency that needs to be
pre-installed before the tests can build.