### PR TITLE
Fix IPv4 octet and mask length overflow (#57)

### DIFF
--- a/test/IPSpec.hs
+++ b/test/IPSpec.hs
@@ -56,8 +56,12 @@ spec = do
         prop "IPv6 failure" ipv6_fail
         it "can read even if unnecessary spaces exist" $ do
             (readMay " 127.0.0.1" :: Maybe IPv4) `shouldBe` readMay "127.0.0.1"
+        it "does not read overflow IPv4 octets" $ do
+            (readMay "127.0.0.18446744073709551617" :: Maybe IPv4) `shouldBe` Nothing
         it "can read even if unnecessary spaces exist" $ do
             (readMay " ::1" :: Maybe IPv4) `shouldBe` readMay "::1"
+        it "does not read overflow mask lengths" $ do
+            (readMay "192.168.0.1/18446744073709551648" :: Maybe (AddrRange IPv4)) `shouldBe` Nothing
 
 to_str_ipv4 :: AddrRange IPv4 -> Bool
 to_str_ipv4 a = readMay (show a) == Just a


### PR DESCRIPTION
The `dig` function in `Data.IP.Addr` uses an `Int` accumulator that can overflow while parsing.  It is used to parse IPv4 octets as well as IPv4 and IPv6 mask lengths.  This change replaces the `dig` function with two special-purpose functions:

The `octet` function parses IPv4 octets.  It checks the maximum bound while parsing so that overflow is not possible.

The `maskLen` function parses mask lengths.  The maximum bound is passed as an argument (32 for IPv4 and 128 for IPv6), and it checks the maximum bound while parsing so that overflow is not possible.  The use of `option` is refactored to only check for the `/` character, so that an invalid mask length after the `/` character can cause a parse failure.

Note that these functions include the following performance optimizations:

* The `ord` function is used instead of `digitToInt`, as the range of characters is already checked.
* The parameters to the `go` helper function are given (bang) strictness annotations to help GHC determine that the `Char` and `Int` values can be unboxed.

An unfortunate side effect of this change is that some error messages change.