### PR TITLE
Handle 0-prefixed octets

### DIFF
--- a/Data/IP/Addr.hs
+++ b/Data/IP/Addr.hs
@@ -491,8 +491,7 @@ instance IsString IPv6 where
 --
 
 octet :: Parser Int
-octet = 0 <$ char '0'
-  <|> (toInt =<< (:) <$> oneOf ['1'..'9'] <*> many digit)
+octet = toInt =<< many digit
   where
     toInt ds = maybe (fail "IPv4 address") pure $ foldr go Just ds 0
     go !d !f !n =


### PR DESCRIPTION
For example, 127.0.0.01 would fail to parse, but is a valid representation of 127.1.

I looked through history and couldn't find any reason the code was special cased to break here.  We discovered this via typo.