### PR TITLE
Check that IPv4 addresses terminate

### DIFF
--- a/Data/IP/Range.hs
+++ b/Data/IP/Range.hs
@@ -118,7 +118,8 @@ maskLen maxLen = do
 
 ip4range :: Parser (AddrRange IPv4)
 ip4range = do
-    ip <- ip4
+    skipSpaces
+    ip <- toIPv4 <$> ip4' False
     len <- maskLen 32
     let msk = maskIPv4 len
         adr = ip `maskedIPv4` msk

--- a/test/IPSpec.hs
+++ b/test/IPSpec.hs
@@ -23,7 +23,13 @@ import RouteTableSpec ()
 data InvalidIPv4Str = Iv4 String deriving (Show)
 
 instance Arbitrary InvalidIPv4Str where
-    arbitrary = arbitraryIIPv4Str arbitrary 32
+    arbitrary = 
+        frequency [(9, arbitraryIIPv4Str arbitrary 32)
+                  ,(1, Iv4 . (++ ".") . show <$> genIPv4)
+                  ]
+      where
+        genIPv4 :: Gen IPv4
+        genIPv4 = arbitrary
 
 arbitraryIIPv4Str :: Gen IPv4 -> Int -> Gen InvalidIPv4Str
 arbitraryIIPv4Str adrGen msklen = toIv4 <$> adrGen <*> lenGen


### PR DESCRIPTION
The existing parser admits `0.0.0.0.` to be parsed as a valid `IPv4` address, while it isn't.