### PR TITLE
IPv4 address with mask should not contain a white space

### DIFF
--- a/Data/IP/Addr.hs
+++ b/Data/IP/Addr.hs
@@ -512,8 +512,8 @@ ip4' checkTermination = do
     _ <- char '.'
     a3 <- octet
     let as = [a0, a1, a2, a3]
-    skipSpaces
-    when checkTermination termination
+    when checkTermination $
+      skipSpaces >> termination
     return as
 
 skipSpaces :: Parser ()

--- a/test/IPSpec.hs
+++ b/test/IPSpec.hs
@@ -24,8 +24,11 @@ data InvalidIPv4Str = Iv4 String deriving (Show)
 
 instance Arbitrary InvalidIPv4Str where
     arbitrary = 
-        frequency [(9, arbitraryIIPv4Str arbitrary 32)
+        frequency [(8, arbitraryIIPv4Str arbitrary 32)
+                   -- an IPv4 address should not end with a trailing `.`
                   ,(1, Iv4 . (++ ".") . show <$> genIPv4)
+                   -- an IPv4 address with mask should not include a white space
+                  ,(1, (\ip (NonNegative len) -> Iv4 (show ip ++ " /" ++ show (len :: Integer))) <$> genIPv4 <*> arbitrary)
                   ]
       where
         genIPv4 :: Gen IPv4


### PR DESCRIPTION
This IPv4 address should be illegal `0.0.0.0 /32`.  This is compatible with `inet_net_pton`.
